### PR TITLE
Closes #1 - Urgent update to node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.2.0
+FROM node:8.11.4
 
 ENV PORT 80
 ENV NODE_ENV production


### PR DESCRIPTION
update node to latest 8LTS

I have not tested this, but there is no possible good reason to use 8.2.0 ...